### PR TITLE
add initialValue fields to schemas, initialValues utility and tests in studio types

### DIFF
--- a/apps/studio/src/lib/schemaTypes/index.ts
+++ b/apps/studio/src/lib/schemaTypes/index.ts
@@ -13,6 +13,7 @@ import catalogBlock from './catalogBlock.js';
 import referenceToPage from './referenceToPage.js';
 import movie from './movie.js';
 import instagramPost from './instagramPost.js';
+import { initialValueTest } from './initialValueTest.js';
 
 export const schemaTypes = [
 	// Document types
@@ -23,6 +24,7 @@ export const schemaTypes = [
 	movie,
 	agent,
 	instagramPost,
+	initialValueTest,
 
 	// Object types (used in other schemas)
 	textBlock,

--- a/apps/studio/src/lib/schemaTypes/initialValueTest.ts
+++ b/apps/studio/src/lib/schemaTypes/initialValueTest.ts
@@ -1,0 +1,322 @@
+import type { DocumentType } from '@aphexcms/cms-core/types/schemas';
+import { FileText } from 'lucide-svelte';
+import { currentDate, currentDateTime, dateFromToday, firstDayOfMonth } from '@aphexcms/cms-core';
+
+export const initialValueTest: DocumentType = {
+	type: 'document',
+	name: 'initialValueTest',
+	title: 'Initial Value Test',
+	description: 'Test document for all field types with initialValue support',
+	icon: FileText,
+	fields: [
+		// String field with literal initialValue
+		{
+			name: 'stringLiteral',
+			type: 'string',
+			title: 'String (Literal)',
+			description: 'Should default to "Hello World"',
+			initialValue: 'Hello World'
+		},
+		// String field with function initialValue
+		{
+			name: 'stringFunction',
+			type: 'string',
+			title: 'String (Function)',
+			description: 'Should default to current timestamp',
+			initialValue: () => `Created at ${new Date().toLocaleString()}`
+		},
+		// String field with async function initialValue
+		{
+			name: 'stringAsync',
+			type: 'string',
+			title: 'String (Async Function)',
+			description: 'Should default to delayed greeting',
+			initialValue: async () => {
+				await new Promise((resolve) => setTimeout(resolve, 100));
+				return 'Async greeting!';
+			}
+		},
+		// Text field with literal initialValue
+		{
+			name: 'textLiteral',
+			type: 'text',
+			title: 'Text (Literal)',
+			description: 'Should default to multi-line text',
+			initialValue: 'This is a long text field.\nWith multiple lines.\nFor testing purposes.'
+		},
+		// Text field with function initialValue
+		{
+			name: 'textFunction',
+			type: 'text',
+			title: 'Text (Function)',
+			description: 'Should default to generated content',
+			initialValue: () => `Generated on:\n${new Date().toISOString()}\n\nEdit this content as needed.`
+		},
+		// Number field with literal initialValue
+		{
+			name: 'numberLiteral',
+			type: 'number',
+			title: 'Number (Literal)',
+			description: 'Should default to 42',
+			initialValue: 42
+		},
+		// Number field with function initialValue
+		{
+			name: 'numberFunction',
+			type: 'number',
+			title: 'Number (Function)',
+			description: 'Should default to random number',
+			initialValue: () => Math.floor(Math.random() * 100)
+		},
+		// Boolean field with literal initialValue (true)
+		{
+			name: 'booleanTrue',
+			type: 'boolean',
+			title: 'Boolean (True)',
+			description: 'Should default to checked',
+			initialValue: true
+		},
+		// Boolean field with literal initialValue (false)
+		{
+			name: 'booleanFalse',
+			type: 'boolean',
+			title: 'Boolean (False)',
+			description: 'Should default to unchecked',
+			initialValue: false
+		},
+		// Boolean field with function initialValue
+		{
+			name: 'booleanFunction',
+			type: 'boolean',
+			title: 'Boolean (Function)',
+			description: 'Should default to random boolean',
+			initialValue: () => Math.random() > 0.5
+		},
+		// Slug field with literal initialValue
+		{
+			name: 'slugLiteral',
+			type: 'slug',
+			title: 'Slug (Literal)',
+			description: 'Should default to "test-slug"',
+			source: 'stringLiteral',
+			initialValue: 'test-slug'
+		},
+		// URL field with literal initialValue
+		{
+			name: 'urlLiteral',
+			type: 'url',
+			title: 'URL (Literal)',
+			description: 'Should default to example.com',
+			initialValue: 'https://example.com'
+		},
+		// URL field with function initialValue
+		{
+			name: 'urlFunction',
+			type: 'url',
+			title: 'URL (Function)',
+			description: 'Should default to timestamped URL',
+			initialValue: () => `https://example.com?created=${Date.now()}`
+		},
+		// Date field with literal initialValue
+		{
+			name: 'dateLiteral',
+			type: 'date',
+			title: 'Date (Literal)',
+			description: 'Should default to 2024-01-01',
+			initialValue: '2024-01-01'
+		},
+		// Date field with function initialValue
+		{
+			name: 'dateFunction',
+			type: 'date',
+			title: 'Date (Function)',
+			description: 'Should default to today',
+			initialValue: currentDate
+		},
+		// Date field with dateFromToday helper
+		{
+			name: 'dateFuture',
+			type: 'date',
+			title: 'Date (7 days from now)',
+			description: 'Should default to 7 days from today',
+			initialValue: () => dateFromToday(7)
+		},
+		// Date field with firstDayOfMonth helper
+		{
+			name: 'dateFirstOfMonth',
+			type: 'date',
+			title: 'Date (First of Month)',
+			description: 'Should default to first day of current month',
+			initialValue: firstDayOfMonth
+		},
+		// DateTime field with literal initialValue
+		{
+			name: 'datetimeLiteral',
+			type: 'datetime',
+			title: 'DateTime (Literal)',
+			description: 'Should default to specific datetime',
+			initialValue: '2024-01-01T12:00:00Z'
+		},
+		// DateTime field with function initialValue
+		{
+			name: 'datetimeFunction',
+			type: 'datetime',
+			title: 'DateTime (Function)',
+			description: 'Should default to current datetime',
+			initialValue: currentDateTime
+		},
+		// Array field with literal initialValue
+		{
+			name: 'arrayLiteral',
+			type: 'array',
+			title: 'Array (Literal)',
+			description: 'Should default to array with 2 items',
+			of: [
+				{
+					type: 'object',
+					name: 'arrayItem',
+					fields: [
+						{
+							name: 'text',
+							type: 'string',
+							title: 'Text'
+						}
+					]
+				}
+			],
+			initialValue: [
+				{ _type: 'arrayItem', text: 'First item' },
+				{ _type: 'arrayItem', text: 'Second item' }
+			]
+		},
+		// Array field with function initialValue
+		{
+			name: 'arrayFunction',
+			type: 'array',
+			title: 'Array (Function)',
+			description: 'Should default to generated array',
+			of: [
+				{
+					type: 'object',
+					name: 'generatedItem',
+					fields: [
+						{
+							name: 'label',
+							type: 'string',
+							title: 'Label'
+						},
+						{
+							name: 'timestamp',
+							type: 'string',
+							title: 'Timestamp'
+						}
+					]
+				}
+			],
+			initialValue: () => [
+				{
+					_type: 'generatedItem',
+					label: 'Generated item',
+					timestamp: new Date().toISOString()
+				}
+			]
+		},
+		// Object field with literal initialValue
+		{
+			name: 'objectLiteral',
+			type: 'object',
+			title: 'Object (Literal)',
+			description: 'Should default to pre-filled object',
+			fields: [
+				{
+					name: 'name',
+					type: 'string',
+					title: 'Name'
+				},
+				{
+					name: 'email',
+					type: 'string',
+					title: 'Email'
+				},
+				{
+					name: 'active',
+					type: 'boolean',
+					title: 'Active'
+				}
+			],
+			initialValue: {
+				name: 'John Doe',
+				email: 'john@example.com',
+				active: true
+			}
+		},
+		// Object field with function initialValue
+		{
+			name: 'objectFunction',
+			type: 'object',
+			title: 'Object (Function)',
+			description: 'Should default to generated object',
+			fields: [
+				{
+					name: 'id',
+					type: 'string',
+					title: 'ID'
+				},
+				{
+					name: 'createdAt',
+					type: 'string',
+					title: 'Created At'
+				}
+			],
+			initialValue: () => ({
+				id: Math.random().toString(36).substring(7),
+				createdAt: new Date().toISOString()
+			})
+		},
+		// Nested objects with initialValues
+		{
+			name: 'arrayOfObjectsWithInitialValues',
+			type: 'array',
+			title: 'Array of Objects (Nested initialValues)',
+			description: 'Items should have initialValues when added',
+			of: [
+				{
+					type: 'object',
+					name: 'nestedItem',
+					fields: [
+						{
+							name: 'title',
+							type: 'string',
+							title: 'Title',
+							initialValue: 'New Item'
+						},
+						{
+							name: 'priority',
+							type: 'number',
+							title: 'Priority',
+							initialValue: 1
+						},
+						{
+							name: 'enabled',
+							type: 'boolean',
+							title: 'Enabled',
+							initialValue: true
+						},
+						{
+							name: 'createdAt',
+							type: 'string',
+							title: 'Created At',
+							initialValue: () => new Date().toISOString()
+						}
+					]
+				}
+			]
+		}
+	],
+	preview: {
+		select: {
+			title: 'stringLiteral',
+			subtitle: 'stringFunction'
+		}
+	},
+};

--- a/packages/cms-core/src/lib/components/admin/ObjectModal.svelte
+++ b/packages/cms-core/src/lib/components/admin/ObjectModal.svelte
@@ -3,6 +3,7 @@
 	import * as Card from '@aphexcms/ui/shadcn/card';
 	import type { SchemaType } from 'src/types/schemas.js';
 	import SchemaField from './SchemaField.svelte';
+	import { getDefaultValueForFieldType } from '../../utils/field-defaults';
 
 	interface Props {
 		open: boolean;
@@ -35,10 +36,17 @@
 
 		if (schema?.fields) {
 			schema.fields.forEach((field) => {
-				if (field.type === 'boolean' && 'initialValue' in field) {
-					initialData[field.name] = field.initialValue;
+				if ('initialValue' in field && field.initialValue !== undefined) {
+					// Only use literal initialValue (skip functions to keep this synchronous)
+					if (typeof field.initialValue !== 'function') {
+						initialData[field.name] = field.initialValue;
+					} else {
+						// Function-based initialValues are skipped for nested items
+						// They will use field type defaults instead
+						initialData[field.name] = getDefaultValueForFieldType(field.type);
+					}
 				} else {
-					initialData[field.name] = '';
+					initialData[field.name] = getDefaultValueForFieldType(field.type);
 				}
 			});
 		}

--- a/packages/cms-core/src/lib/components/admin/fields/ArrayField.svelte
+++ b/packages/cms-core/src/lib/components/admin/fields/ArrayField.svelte
@@ -10,6 +10,7 @@
 	import { getSchemaContext } from '../../../schema-context.svelte';
 	import ObjectModal from '../ObjectModal.svelte';
 	import ImageField from './ImageField.svelte';
+	import { getDefaultValueForFieldType } from '../../../utils/field-defaults';
 
 	interface Props {
 		field: ArrayFieldType;
@@ -129,10 +130,17 @@
 
 		if (schema.fields) {
 			schema.fields.forEach((field) => {
-				if (field.type === 'boolean' && 'initialValue' in field) {
-					newItem[field.name] = field.initialValue;
+				if ('initialValue' in field && field.initialValue !== undefined) {
+					// Only use literal initialValue (skip functions to keep this synchronous)
+					if (typeof field.initialValue !== 'function') {
+						newItem[field.name] = field.initialValue;
+					} else {
+						// Function-based initialValues are skipped for nested items
+						// They will use field type defaults instead
+						newItem[field.name] = getDefaultValueForFieldType(field.type);
+					}
 				} else {
-					newItem[field.name] = '';
+					newItem[field.name] = getDefaultValueForFieldType(field.type);
 				}
 			});
 		}

--- a/packages/cms-core/src/lib/components/admin/fields/StringField.svelte
+++ b/packages/cms-core/src/lib/components/admin/fields/StringField.svelte
@@ -108,10 +108,8 @@
 			const isValid = items.some((item) => item.value === value);
 
 			if (!isValid) {
-				// Current value not in new options - reset to first option or initialValue
-				const newValue = field.initialValue && items.some((item) => item.value === field.initialValue)
-					? field.initialValue
-					: items[0]?.value || '';
+				// Current value not in new options - reset to first option
+				const newValue = items[0]?.value || '';
 
 				console.log(`🔄 Dependent field "${field.name}" reset: "${value}" → "${newValue}"`);
 				onUpdate(newValue);
@@ -131,7 +129,7 @@
 	{#if layout === 'radio'}
 		<!-- Radio Button Layout -->
 		<RadioGroup.Root
-			value={value || field.initialValue || ''}
+			value={value || ''}
 			onValueChange={handleSelectChange}
 			disabled={readonly}
 			class={validationClasses}
@@ -150,7 +148,7 @@
 		<Select.Root
 			type="single"
 			name={field.name}
-			value={value || field.initialValue || ''}
+			value={value || ''}
 			onValueChange={handleSelectChange}
 			disabled={readonly}
 		>
@@ -175,7 +173,7 @@
 	<!-- Regular Input -->
 	<Input
 		id={field.name}
-		value={value || field.initialValue || ''}
+		value={value || ''}
 		placeholder={field.placeholder || field.title}
 		oninput={handleInputChange}
 		onblur={onBlur}

--- a/packages/cms-core/src/lib/types/schemas.ts
+++ b/packages/cms-core/src/lib/types/schemas.ts
@@ -34,7 +34,7 @@ export interface StringField extends BaseField {
 	type: 'string';
 	maxLength?: number;
 	placeholder?: string;
-	initialValue?: string;
+	initialValue?: string | (() => string | Promise<string>);
 	list?: Array<string | { title: string; value: string }> | DependentList;
 	options?: {
 		layout?: 'dropdown' | 'radio';
@@ -47,29 +47,32 @@ export interface TextField extends BaseField {
 	rows?: number;
 	maxLength?: number;
 	placeholder?: string;
+	initialValue?: string | (() => string | Promise<string>);
 }
 
 export interface NumberField extends BaseField {
 	type: 'number';
 	min?: number;
 	max?: number;
+	initialValue?: number | (() => number | Promise<number>);
 }
 
 export interface BooleanField extends BaseField {
 	type: 'boolean';
-	initialValue?: boolean;
+	initialValue?: boolean | (() => boolean | Promise<boolean>);
 }
 
 export interface SlugField extends BaseField {
 	type: 'slug';
 	source?: string;
 	maxLength?: number;
+	initialValue?: string | (() => string | Promise<string>);
 }
 
 export interface URLField extends BaseField {
 	type: 'url';
 	placeholder?: string;
-	initialValue?: string;
+	initialValue?: string | (() => string | Promise<string>);
 }
 
 export interface ImageField extends BaseField {
@@ -79,6 +82,7 @@ export interface ImageField extends BaseField {
 	metadata?: string[]; // e.g., ['palette', 'exif', 'location']
 	fields?: Field[]; // Additional fields like caption, attribution
 	private?: boolean; // Default: false (public). Set true to require auth for access
+	initialValue?: string | (() => string | Promise<string>);
 }
 
 export interface TypeReference {
@@ -91,11 +95,13 @@ export interface TypeReference {
 export interface ArrayField extends BaseField {
 	type: 'array';
 	of: TypeReference[];
+	initialValue?: any[] | (() => any[] | Promise<any[]>);
 }
 
 export interface ObjectField extends BaseField {
 	type: 'object';
 	fields: Field[];
+	initialValue?: Record<string, any> | (() => Record<string, any> | Promise<Record<string, any>>);
 }
 
 export interface DateField extends BaseField {
@@ -104,6 +110,7 @@ export interface DateField extends BaseField {
 		dateFormat?: string; // Default: 'YYYY-MM-DD' (Moment.js format)
 		calendarTodayLabel?: string; // Label for "today" button
 	};
+	initialValue?: string | (() => string | Promise<string>);
 }
 
 export interface DateTimeField extends BaseField {
@@ -115,11 +122,13 @@ export interface DateTimeField extends BaseField {
 		allowTimeZoneSwitch?: boolean; // Allow user timezone switching (Default: true)
 		displayTimeZone?: string; // Specific timezone for display (stored as UTC)
 	};
+	initialValue?: string | (() => string | Promise<string>);
 }
 
 export interface ReferenceField extends BaseField {
 	type: 'reference';
 	to: Array<{ type: string }>;
+	initialValue?: any | (() => any | Promise<any>);
 }
 
 export type Field =
@@ -145,7 +154,7 @@ export interface PreviewConfig {
 }
 
 export interface DocumentType {
-	id: string;
+	id?: string;
 	type: 'document';
 	name: string;
 	title: string;
@@ -153,8 +162,8 @@ export interface DocumentType {
 	icon?: typeof LucideIcon;
 	fields: Field[];
 	preview?: PreviewConfig;
-	createdAt: Date | null;
-	updatedAt: Date | null;
+	createdAt?: Date | null;
+	updatedAt?: Date | null;
 }
 
 export interface ObjectType {

--- a/packages/cms-core/src/lib/utils/field-defaults.ts
+++ b/packages/cms-core/src/lib/utils/field-defaults.ts
@@ -1,0 +1,22 @@
+import type { FieldType } from '../types/schemas';
+
+/**
+ * Get the default value for a field type
+ * @param fieldType - The field type
+ * @returns The default value for the field type
+ */
+export function getDefaultValueForFieldType(fieldType: FieldType): any {
+	switch (fieldType) {
+		case 'boolean':
+			return false;
+		case 'array':
+			return [];
+		case 'object':
+			return {};
+		case 'number':
+			return null;
+		default:
+			// string, text, slug, url, image, date, datetime, reference
+			return '';
+	}
+}

--- a/packages/cms-core/src/lib/utils/index.ts
+++ b/packages/cms-core/src/lib/utils/index.ts
@@ -10,3 +10,4 @@ export * from '../field-validation/utils';
 export * from './content-hash';
 export * from './slug';
 export * from './image-url';
+export * from './initial-value-helpers';

--- a/packages/cms-core/src/lib/utils/initial-value-helpers.ts
+++ b/packages/cms-core/src/lib/utils/initial-value-helpers.ts
@@ -1,0 +1,85 @@
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(utc);
+
+/**
+ * Helper functions for initialValue date/datetime patterns
+ * These can be used directly as initialValue in field definitions
+ *
+ * Note: Returns values in storage format (ISO),
+ * which will be converted to the user's configured display format by the field components
+ */
+
+// ==================== Date Helpers ====================
+
+/**
+ * Returns the current date in YYYY-MM-DD format (storage format)
+ * Usage: initialValue: currentDate
+ */
+export function currentDate(): string {
+	return dayjs().format('YYYY-MM-DD');
+}
+
+/**
+ * Returns a specific date offset from today
+ * Usage: initialValue: () => dateFromToday(7) // 7 days from now
+ * Usage: initialValue: () => dateFromToday(-7) // 7 days ago
+ */
+export function dateFromToday(days: number): string {
+	return dayjs().add(days, 'day').format('YYYY-MM-DD');
+}
+
+/**
+ * Returns the first day of the current month
+ * Usage: initialValue: firstDayOfMonth
+ */
+export function firstDayOfMonth(): string {
+	return dayjs().startOf('month').format('YYYY-MM-DD');
+}
+
+/**
+ * Returns the last day of the current month
+ * Usage: initialValue: lastDayOfMonth
+ */
+export function lastDayOfMonth(): string {
+	return dayjs().endOf('month').format('YYYY-MM-DD');
+}
+
+// ==================== DateTime Helpers ====================
+
+/**
+ * Returns the current datetime in ISO UTC format (storage format)
+ * Usage: initialValue: currentDateTime
+ */
+export function currentDateTime(): string {
+	return dayjs().utc().format('YYYY-MM-DDTHH:mm:ss[Z]');
+}
+
+/**
+ * Returns a datetime offset from now in ISO UTC format
+ * Usage: initialValue: () => dateTimeFromNow(1, 'hour') // 1 hour from now
+ * Usage: initialValue: () => dateTimeFromNow(-30, 'minute') // 30 minutes ago
+ */
+export function dateTimeFromNow(
+	amount: number,
+	unit: 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year'
+): string {
+	return dayjs().add(amount, unit).utc().format('YYYY-MM-DDTHH:mm:ss[Z]');
+}
+
+/**
+ * Returns the start of the current day in ISO UTC format
+ * Usage: initialValue: startOfToday
+ */
+export function startOfToday(): string {
+	return dayjs().startOf('day').utc().format('YYYY-MM-DDTHH:mm:ss[Z]');
+}
+
+/**
+ * Returns the end of the current day in ISO UTC format
+ * Usage: initialValue: endOfToday
+ */
+export function endOfToday(): string {
+	return dayjs().endOf('day').utc().format('YYYY-MM-DDTHH:mm:ss[Z]');
+}


### PR DESCRIPTION
- added helpers for date & datetime functionality. <- USEFUL PERHAPS - not supporting timezone override. uses browser timezone