### PR TITLE
feat: enforce private file fields, add signed asset URLs

### DIFF
--- a/.changeset/private-assets-signed-urls.md
+++ b/.changeset/private-assets-signed-urls.md
@@ -1,0 +1,92 @@
+---
+'@aphexcms/cms-core': minor
+---
+
+Private assets are actually enforced, and reachable by signed URL.
+
+## `private` on a file field did nothing
+
+`FileField` declares `private?: boolean` in the schema types, the docs describe it, and the CDN
+route never checked it — the privacy test read `if (field.type === 'image')`. A `file` field marked
+`private: true` served its PDF to anyone holding the URL.
+
+A privacy control that is silently ignored is worse than one that doesn't exist, because the schema
+says it is on. Both `image` and `file` are now checked.
+
+## Library uploads had no privacy at all
+
+Privacy is resolved from `schemaType` + `fieldPath`, recorded on the asset at upload. The media
+browser — the main upload path in the DAM release — sent neither, so every asset uploaded through
+the library evaluated as public regardless of where it was later used.
+
+The picker now carries the field it was opened from (`ImageField`/`FileField` →
+`AssetBrowserModal` → `MediaBrowser`), so an upload made from inside a private field inherits it.
+Opening the Media tab directly still has no field to inherit from, which is correct.
+
+## Signed URLs, on your own domain
+
+`security.assetSigningSecret` has been in the config type since before this release, referenced by
+the docs, and read by nothing. It now works.
+
+`signAssetUrl()` (exported from `@aphexcms/cms-core/server`) appends `?exp=…&sig=…` to a
+`/media/...` path; the route verifies it before the session checks and treats it as sufficient. That
+is what makes a private asset usable in an `<img>`, a `<video>`, or an emailed link — none of which
+carry an admin cookie.
+
+Deliberately **not** `signedDownloads`, which redirects to a signed URL on the _bucket_: that hands
+the viewer a storage-provider URL, exposes the key layout, and takes the request outside every check
+this route performs, byte ranges and derivative selection included. Signing our own URL keeps all of
+it in place and the bucket closed.
+
+The signature covers the **asset id and expiry only**. Not the filename, which is cosmetic and would
+make a rename break live links; not the requested width, since a responsive `srcset` asks for one
+image at several widths and binding it would mean a signature per breakpoint. A signature answers
+"may this caller read this asset", not "which rendition".
+
+Fails closed throughout: with no secret configured, signing returns the URL untouched and
+verification always fails, so a misconfiguration costs access rather than granting it. Expired,
+tampered and mismatched signatures are rejected identically, without reporting which.
+
+## Renaming a private field used to publish its assets
+
+Privacy is not stored on the asset — the asset stores a _pointer_ to the field it was uploaded into,
+and the answer is recomputed from the live schema on every request. That is what makes toggling
+`private: true` in code apply immediately, with no migration.
+
+It also meant the answer could stop being computable. Rename or delete that field and the lookup
+returned nothing, which the route read as **public** — so a rename silently exposed everything
+behind it.
+
+The resolved value is now also stamped on the asset at upload and used as the fallback when the
+pointer no longer resolves. The live schema still wins whenever it can answer, so nothing about
+toggling changes. `resolveFieldPrivacy` returns `null` rather than `false` for "cannot answer",
+which is what lets the two cases be told apart; when the fallback fires it logs the asset and the
+dead path rather than passing silently.
+
+An asset with neither pointer nor stamp stays public. Defaulting those to private would make every
+pre-existing library asset inaccessible overnight.
+
+The field-walking logic moved out of the CDN route into `utils/asset-privacy.ts`, shared with the
+upload path so the two cannot disagree about what "private" means.
+
+## A lock badge in the library
+
+Privacy is declared on a schema field, so nothing in the media library indicated which assets a
+`private: true` actually covered — and the honest answer (only those uploaded through that field) is
+surprising enough to be worth showing. Private assets now carry a lock on the tile and a line in the
+inspector explaining what it means and where it came from.
+
+Computed server-side and reported as `isPrivate` on the list response, because it depends on the
+live schema and an asset uploaded before stamping has no local answer at all — a client-side guess
+would under-report exactly the assets the badge exists to identify.
+
+Read-only, deliberately. A toggle here would introduce asset-level privacy as a second source of
+truth alongside the field, with no rule for what happens when they disagree; that belongs with the
+escalate-on-save work rather than bolted on beside it.
+
+## Known limit
+
+Privacy still comes from the field an asset was **uploaded into**, so an asset uploaded publicly and
+later reused in a private field stays public. Documented in the schema and storage guides. Deriving
+it from the asset-reference index instead would be wrong in the dangerous direction — that index
+fails open, and access control must fail closed.

--- a/apps/studio/.env.example
+++ b/apps/studio/.env.example
@@ -47,6 +47,13 @@ DATABASE_URL="postgres://root:my-secret-password@localhost:5432/local"
 ##   node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
 # APHEX_SECRET_ENCRYPTION_KEY=
 
+## Signs asset URLs so a private asset can be served without an admin session —
+## an <img>, a <video>, or a link in an email. Mint them with `signAssetUrl` from
+## `@aphexcms/cms-core/server`. When unset, signing is a no-op and verification
+## always fails, so private assets stay reachable only with a session. Generate:
+##   node -e "console.log(require('crypto').randomBytes(32).toString('base64url'))"
+# APHEX_ASSET_SIGNING_SECRET=
+
 ## Background job worker
 ## ---------------------
 ## Shared secret that authorizes POST /api/internal/workers/run (Authorization:

--- a/apps/studio/aphex.config.ts
+++ b/apps/studio/aphex.config.ts
@@ -61,7 +61,14 @@ export default createCMSConfig({
 		// unset, secret settings fields are disabled (read-only) rather than stored as
 		// plaintext. Keep it stable across deploys; rotating it orphans existing secrets.
 		// Read via `$env/dynamic/private` — SvelteKit does NOT put `.env` into process.env.
-		secretEncryptionKey: env.APHEX_SECRET_ENCRYPTION_KEY
+		secretEncryptionKey: env.APHEX_SECRET_ENCRYPTION_KEY,
+
+		// Signs `/media/:id/:filename` URLs, so a private asset can be handed to a
+		// viewer with no admin session — one asset, for a bounded window. Mint links
+		// with `signAssetUrl` from `@aphexcms/cms-core/server`. When unset, signing
+		// is a no-op and verification always fails, so private assets remain
+		// reachable only with a session (fail closed).
+		assetSigningSecret: env.APHEX_ASSET_SIGNING_SECRET
 	},
 
 	// Background jobs — the durable spine that runs scheduled publishes and event consumers.

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -31,7 +31,9 @@
 		"test:all": "vitest run comprehensive",
 		"test:rbac": "APHEX_TEST_SHARED_DB=true vitest run --no-file-parallelism tests/api-key-rbac.test.ts",
 		"test:coverage": "vitest run --coverage",
-		"test:date": "tsx scripts/test-date-localapi.ts"
+		"test:date": "tsx scripts/test-date-localapi.ts",
+		"sign-url": "tsx --env-file-if-exists=.env scripts/sign-asset-url.ts",
+		"private-asset-check": "tsx --env-file-if-exists=.env scripts/private-asset-check.ts"
 	},
 	"dependencies": {
 		"@aphexcms/ai-openai": "workspace:*",

--- a/apps/studio/scripts/private-asset-check.ts
+++ b/apps/studio/scripts/private-asset-check.ts
@@ -1,0 +1,66 @@
+/**
+ * End-to-end check for private assets + signed URLs, against a running server.
+ *
+ *   pnpm -F @aphexcms/studio private-asset-check <assetId> <filename>
+ *
+ * Deliberately HTTP-only: it reads no database and changes nothing. The setup it
+ * needs is an asset uploaded *through a field marked `private: true`*, because
+ * that is what records the field context the media route reads. Do that in the
+ * admin first, then pass the id here.
+ *
+ * `$env/dynamic/private` is a Vite virtual module, so a tsx script cannot import
+ * the app's db layer even if it wanted to — which is just as well, since the
+ * alternative was editing metadata on real content to fake a private asset.
+ */
+import { signAssetUrl } from '@aphexcms/cms-core/server';
+
+const BASE = process.env.APHEX_PUBLIC_URL ?? 'http://localhost:5173';
+
+const [assetId, filename] = process.argv.slice(2);
+if (!assetId || !filename) {
+	console.error('usage: private-asset-check <assetId> <filename>');
+	process.exit(1);
+}
+
+const secret = process.env.APHEX_ASSET_SIGNING_SECRET;
+if (!secret) {
+	console.error('APHEX_ASSET_SIGNING_SECRET is not set — nothing to verify.');
+	process.exit(1);
+}
+
+const path = `/media/${assetId}/${encodeURIComponent(filename)}`;
+
+async function check(label: string, url: string, expected: number) {
+	// `redirect: 'manual'` so a signedDownloads redirect shows as a 302 rather
+	// than silently following to the bucket and reporting its status.
+	const res = await fetch(url, { redirect: 'manual' });
+	const ok = res.status === expected ? 'PASS' : 'FAIL';
+	console.log(`${ok}  ${label.padEnd(28)} ${res.status}  (expect ${expected})`);
+	return res.status === expected;
+}
+
+const sign = (id: string, expiresIn: number) =>
+	`${BASE}${signAssetUrl(secret, path, id, { expiresIn })}`;
+
+const results = [
+	// No signature, no session — the whole point of marking a field private.
+	await check('unsigned', `${BASE}${path}`, 401),
+	await check('signed', sign(assetId, 300), 200),
+	// A signature is for one asset, so one minted for a different id must not open this.
+	await check(
+		'signature for another asset',
+		sign('00000000-0000-4000-8000-000000000000', 300),
+		401
+	),
+	// The deadline is inside the signature, so an expired one cannot be revived.
+	await check('expired signature', sign(assetId, -60), 401),
+	// Tampering with the expiry invalidates the signature rather than extending it.
+	await check(
+		'tampered expiry',
+		sign(assetId, 300).replace(/exp=\d+/, `exp=${Math.floor(Date.now() / 1000) + 99999}`),
+		401
+	)
+];
+
+console.log(results.every(Boolean) ? '\nall checks passed' : '\nFAILURES — see above');
+process.exit(results.every(Boolean) ? 0 : 1);

--- a/apps/studio/scripts/sign-asset-url.ts
+++ b/apps/studio/scripts/sign-asset-url.ts
@@ -1,0 +1,50 @@
+/**
+ * Mint a signed `/media/...` URL for an asset, from the command line.
+ *
+ * Signing needs the secret, so it can only happen server-side — this is the
+ * smallest way to get a real signed URL in your hands without first building a
+ * page that produces one.
+ *
+ *   pnpm -F @aphexcms/studio sign-url <assetId> [filename] [--expires 3600]
+ *
+ * Prints the path and a full localhost URL. Pair it with the unsigned URL to see
+ * both halves of the check:
+ *
+ *   curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:5173/media/<id>/<file>'
+ *   curl -s -o /dev/null -w '%{http_code}\n' '<the signed URL this prints>'
+ *
+ * A private asset answers 401 to the first and 200 to the second.
+ */
+import { signAssetUrl } from '@aphexcms/cms-core/server';
+
+const [assetId, maybeFilename] = process.argv.slice(2).filter((arg) => !arg.startsWith('--'));
+
+if (!assetId) {
+	console.error('usage: sign-asset-url <assetId> [filename] [--expires <seconds>]');
+	process.exit(1);
+}
+
+const expiresFlag = process.argv.indexOf('--expires');
+const expiresIn = expiresFlag === -1 ? 900 : Number(process.argv[expiresFlag + 1]);
+
+const secret = process.env.APHEX_ASSET_SIGNING_SECRET;
+if (!secret) {
+	// Being loud about this matters: without a secret `signAssetUrl` returns the
+	// URL untouched, which looks like success and then 401s. Fail closed, and say so.
+	console.error(
+		'APHEX_ASSET_SIGNING_SECRET is not set — signing would silently return an unsigned URL.\n' +
+			'Add it to apps/studio/.env. Generate one with:\n' +
+			"  node -e \"console.log(require('crypto').randomBytes(32).toString('base64url'))\""
+	);
+	process.exit(1);
+}
+
+// The filename segment is cosmetic — the route resolves the asset by id — so any
+// placeholder works when you don't have the real one to hand.
+const filename = maybeFilename ?? 'file';
+const path = signAssetUrl(secret, `/media/${assetId}/${filename}`, assetId, { expiresIn });
+
+const base = process.env.APHEX_PUBLIC_URL ?? 'http://localhost:5173';
+console.log(path);
+console.log(`${base}${path}`);
+console.error(`\n(valid for ${expiresIn}s)`);

--- a/docs/aphex-docs/content/docs/configuration.mdx
+++ b/docs/aphex-docs/content/docs/configuration.mdx
@@ -418,9 +418,13 @@ createCMSConfig({
 });
 ```
 
-| Option               | Type     | Default | Description                                                                                                                                                |
-| -------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `assetSigningSecret` | `string` | —       | Secret key for HMAC-signed asset URLs. Enables temporary, expiring URLs for multi-tenant asset access without exposing API keys. Should be 32+ characters. |
+| Option               | Type     | Default | Description                                                                                                                                                          |
+| -------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `assetSigningSecret` | `string` | —       | Secret key for HMAC-signed asset URLs. Lets a private asset be served to a viewer with no admin session — one asset, for a bounded window. Should be 32+ characters. |
+
+Mint links with `signAssetUrl` from `@aphexcms/cms-core/server`; see
+[Private assets](/docs/storage#private-assets) for the full flow. Without this secret, signing is a
+no-op and verification always fails, so private assets stay reachable only with a session.
 
 ## aiProvider
 

--- a/docs/aphex-docs/content/docs/schemas/file.mdx
+++ b/docs/aphex-docs/content/docs/schemas/file.mdx
@@ -76,4 +76,11 @@ The asset record tracks the original filename, MIME type, size, and storage adap
 }
 ```
 
-Private files are served from `/media/[id]/[filename]` only if the requester has a valid session for the owning organization.
+Private files are served from `/media/[id]/[filename]` only if the requester has a valid session for
+the owning organization, or presents a [signed URL](/docs/storage#signed-urls) — which is how you
+hand a file to someone who has no admin account.
+
+<Callout type="warn">
+	Privacy is resolved from the field the asset was **uploaded into**. Uploading a file through the
+	media library and then referencing it here leaves it public; upload it through this field instead.
+</Callout>

--- a/docs/aphex-docs/content/docs/schemas/image.mdx
+++ b/docs/aphex-docs/content/docs/schemas/image.mdx
@@ -88,7 +88,14 @@ Mark a field `private` when the image should only be served to authenticated mem
 }
 ```
 
-Requests to `/media/[id]/[filename]` for a private asset return `401` unless the request carries a valid session (or a signed URL).
+Requests to `/media/[id]/[filename]` for a private asset return `401` unless the request carries a
+valid session, or a [signed URL](/docs/storage#signed-urls) — the way to show a private image to a
+visitor with no admin account.
+
+<Callout type="warn">
+	Privacy is resolved from the field the asset was **uploaded into**. An image uploaded through the
+	media library and then referenced here stays public; upload it through this field instead.
+</Callout>
 
 ### In a document
 

--- a/docs/aphex-docs/content/docs/storage.mdx
+++ b/docs/aphex-docs/content/docs/storage.mdx
@@ -234,7 +234,7 @@ Stored in the asset's `metadata` JSONB column.
 Assets served through the CDN route `/media/[id]/[filename]` go through the same auth + capability stack as documents:
 
 - **Public assets** — served without authentication.
-- **Private assets** — fields marked `private: true` in your schema require an authenticated session.
+- **Private assets** — fields marked `private: true` in your schema require an authenticated session, **or a signed URL**.
 - **Organization isolation** — assets respect the same multi-tenant rules as documents. Parent orgs can read child org assets.
 
 Every asset is **proxied** through this route by default, including S3 and R2 ones — the bytes are
@@ -263,6 +263,91 @@ export default createCMSConfig({
 
 Requires `getSignedUrl` on the adapter. Without it the route proxies anyway rather than failing —
 serving the file correctly beats refusing to serve it.
+
+## Private assets
+
+Mark a field `private: true` and any asset uploaded into it requires authorization to read:
+
+```ts
+{ name: 'contract', type: 'file', private: true }
+{ name: 'proofSheet', type: 'image', private: true }
+```
+
+Both `image` and `file` fields support it. A request for a private asset without authorization gets
+`401`; with a session belonging to another organization, `403`. Private responses are always sent
+`Cache-Control: private, no-store`, so they never land in a shared cache.
+
+<Callout type="warn">
+	Privacy is resolved from the field an asset was **uploaded into**, recorded on the asset at upload
+	time. An asset uploaded into a public field and later reused in a private one stays public. If you
+	need an asset to be private, upload it through the private field — the media library passes the
+	field along when you open it from one.
+</Callout>
+
+### Signed URLs
+
+A session is the wrong mechanism for a public-facing page: an `<img>`, a `<video>`, or a link in an
+email carries no admin cookie. A signed URL grants **one asset for a bounded window**, so your app
+can decide who may see a file and then hand them a link that proves it.
+
+Set a secret:
+
+```ts title="aphex.config.ts"
+export default createCMSConfig({
+	security: {
+		// Long and random; keep it out of source and stable across deploys.
+		assetSigningSecret: env.APHEX_ASSET_SIGNING_SECRET
+	}
+});
+```
+
+Then mint links server-side, where the secret lives — a `load` function, an API route, an email
+renderer:
+
+```ts title="src/routes/contracts/+page.server.ts"
+import { signAssetUrl } from '@aphexcms/cms-core/server';
+
+export async function load({ locals }) {
+	const contract = await getContractFor(locals.user);
+
+	return {
+		// Valid for one hour, for this asset only.
+		url: signAssetUrl(
+			locals.aphexCMS.config.security?.assetSigningSecret,
+			`/media/${contract.assetId}/${contract.filename}`,
+			contract.assetId,
+			{ expiresIn: 3600 }
+		)
+	};
+}
+```
+
+The result is an ordinary URL on your own domain:
+
+```
+/media/b3f1c0de-…/contract.pdf?exp=1736450000&sig=8Qb2…
+```
+
+Everything still runs through the media route, so range requests, image derivatives and access
+checks all behave exactly as they do for any other asset. The bucket stays private and its key
+layout stays invisible — unlike `signedDownloads` above, which redirects the viewer to a URL on the
+storage provider.
+
+**What the signature covers.** The asset id and the expiry, and nothing else. Not the filename,
+which is cosmetic and would make a rename break live links. Not the requested width either — a
+responsive `srcset` asks for the same image at several widths, so binding the width would mean a
+signature per breakpoint. A signature answers _"may this caller read this asset"_, not _"which
+rendition"_; every derivative is the same picture, and the access decision is identical for all of
+them.
+
+**Failure is closed.** With no `assetSigningSecret` configured, `signAssetUrl` returns the URL
+unchanged and verification always fails — so a misconfiguration costs access rather than granting
+it. Expired, tampered and mismatched signatures are all rejected identically, without saying why.
+
+<Callout>
+	Signed URLs are only *needed* for private assets. Public ones are served to anyone with the link,
+	as in any CMS — signing them adds nothing.
+</Callout>
 
 ## Adapter tracking and migrations
 

--- a/packages/cms-core/src/lib/components/admin/AssetBrowserModal.svelte
+++ b/packages/cms-core/src/lib/components/admin/AssetBrowserModal.svelte
@@ -14,6 +14,12 @@
 		assetTypeFilter?: 'image' | 'file';
 		/** Asset IDs already in use (shown with a tick in the browser) */
 		existingAssetIds?: Set<string>;
+		/**
+		 * The field that opened this picker. Passed through so an upload made from
+		 * inside a private field inherits that field's privacy — see MediaBrowser.
+		 */
+		schemaType?: string;
+		fieldPath?: string;
 	}
 
 	let {
@@ -23,7 +29,9 @@
 		onSelectMultiple,
 		multiSelect = false,
 		assetTypeFilter = 'image',
-		existingAssetIds
+		existingAssetIds,
+		schemaType,
+		fieldPath
 	}: Props = $props();
 
 	function handleSelect(asset: Asset) {
@@ -55,9 +63,18 @@
 						onSelectMultiple={handleSelectMultiple}
 						{assetTypeFilter}
 						{existingAssetIds}
+						{schemaType}
+						{fieldPath}
 					/>
 				{:else}
-					<MediaBrowser selectable onSelect={handleSelect} {assetTypeFilter} {existingAssetIds} />
+					<MediaBrowser
+						selectable
+						onSelect={handleSelect}
+						{assetTypeFilter}
+						{existingAssetIds}
+						{schemaType}
+						{fieldPath}
+					/>
 				{/if}
 			</div>
 			<div class="border-border flex justify-end border-t px-4 py-3">

--- a/packages/cms-core/src/lib/components/admin/MediaBrowser.svelte
+++ b/packages/cms-core/src/lib/components/admin/MediaBrowser.svelte
@@ -92,6 +92,21 @@
 		 * routing; it only reports.
 		 */
 		onAssetOpen?: (assetId: string | null) => void;
+		/**
+		 * The field this browser was opened from, when it was opened as a picker.
+		 *
+		 * Recorded on anything uploaded here, because it is what the media route
+		 * later reads to decide whether the asset is private: privacy is declared
+		 * on the field (`private: true`), and resolved from the field an asset was
+		 * uploaded into. Without it, everything uploaded through the library is
+		 * public regardless of where it is used — which was the case for every
+		 * library upload until now.
+		 *
+		 * Absent when the library is opened as a destination in its own right (the
+		 * Media tab), where there is no field to inherit from.
+		 */
+		schemaType?: string;
+		fieldPath?: string;
 	}
 
 	let {
@@ -104,7 +119,9 @@
 		active = true,
 		existingAssetIds,
 		assetId = null,
-		onAssetOpen
+		onAssetOpen,
+		schemaType,
+		fieldPath
 	}: Props = $props();
 
 	// State
@@ -825,6 +842,9 @@
 
 			const result = await assets.uploadFile(item.file, {
 				direct: directUpload,
+				// Absent for a plain Media-tab upload; see the prop docs.
+				schemaType,
+				fieldPath,
 				videoDuration: videoInfo.duration,
 				videoWidth: videoInfo.width,
 				videoHeight: videoInfo.height,
@@ -2009,6 +2029,21 @@
 											: 'hover:border-muted-foreground/40 hover:shadow-sm'}"
 								>
 									<div class="bg-muted/30 relative aspect-square overflow-hidden">
+										<!-- Private assets are marked, because nothing else on the tile
+										     distinguishes one. Privacy is declared on a schema field rather
+										     than chosen here, so without a badge an editor has no way to see
+										     which assets a `private: true` actually covers — and the honest
+										     answer (only those uploaded through that field) is surprising.
+										     Read-only: it reports the schema's decision rather than offering
+										     to change it. -->
+										{#if asset.isPrivate}
+											<span
+												class="pointer-events-none absolute top-1.5 left-1.5 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-black/70"
+												title="Private — needs a session or a signed URL"
+											>
+												<Lock class="h-3 w-3 text-white" />
+											</span>
+										{/if}
 										<!-- Playable media reads as playable at a glance. Without this a
 										     video and a PDF differ only by a small glyph, which the
 										     media-kind filter made obvious: narrowing to Video produced a
@@ -2099,6 +2134,21 @@
 											: 'hover:border-muted-foreground/40 hover:shadow-sm'}"
 								>
 									<div class="bg-muted/30 relative aspect-square overflow-hidden">
+										<!-- Private assets are marked, because nothing else on the tile
+										     distinguishes one. Privacy is declared on a schema field rather
+										     than chosen here, so without a badge an editor has no way to see
+										     which assets a `private: true` actually covers — and the honest
+										     answer (only those uploaded through that field) is surprising.
+										     Read-only: it reports the schema's decision rather than offering
+										     to change it. -->
+										{#if asset.isPrivate}
+											<span
+												class="pointer-events-none absolute top-1.5 left-1.5 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-black/70"
+												title="Private — needs a session or a signed URL"
+											>
+												<Lock class="h-3 w-3 text-white" />
+											</span>
+										{/if}
 										<!-- Playable media reads as playable at a glance. Without this a
 										     video and a PDF differ only by a small glyph, which the
 										     media-kind filter made obvious: narrowing to Video produced a
@@ -2642,6 +2692,19 @@
 									? ` · ${formatDuration(selectedAsset)}`
 									: ''}
 							</p>
+							<!-- Spelled out here rather than left to the tile's lock icon: this
+							     is where someone comes to ask "why can't the site show this?",
+							     and a badge alone doesn't say what private *means* or how the
+							     asset became private. -->
+							{#if selectedAsset.isPrivate}
+								<p class="text-muted-foreground mt-1.5 flex items-start gap-1.5 text-xs">
+									<Lock class="mt-[1px] h-3 w-3 shrink-0" />
+									<span>
+										Private — needs a signed URL or a session in this organization. Set by the
+										schema field this asset was uploaded into.
+									</span>
+								</p>
+							{/if}
 						</div>
 
 						<!-- Actions -->

--- a/packages/cms-core/src/lib/components/admin/fields/FileField.svelte
+++ b/packages/cms-core/src/lib/components/admin/fields/FileField.svelte
@@ -495,6 +495,8 @@
 	bind:open={showAssetBrowser}
 	onOpenChange={(v) => (showAssetBrowser = v)}
 	assetTypeFilter="file"
+	{schemaType}
+	{fieldPath}
 	onSelect={(asset) => {
 		const fileValue: FileValue = {
 			_type: 'file',

--- a/packages/cms-core/src/lib/components/admin/fields/ImageField.svelte
+++ b/packages/cms-core/src/lib/components/admin/fields/ImageField.svelte
@@ -629,6 +629,8 @@
 	bind:open={showAssetBrowser}
 	onOpenChange={(v) => (showAssetBrowser = v)}
 	assetTypeFilter="image"
+	{schemaType}
+	{fieldPath}
 	onSelect={(asset) => {
 		const imageValue: ImageValue = {
 			_type: 'image',

--- a/packages/cms-core/src/lib/routes/assets-cdn.ts
+++ b/packages/cms-core/src/lib/routes/assets-cdn.ts
@@ -1,4 +1,6 @@
 import type { RequestHandler } from '@sveltejs/kit';
+import { verifyAssetSignature } from '../utils/asset-url-signing';
+import { isAssetPrivate, resolveFieldPrivacy } from '../utils/asset-privacy';
 import { cmsLogger } from '../utils/logger';
 import {
 	parseVariantFilename,
@@ -128,63 +130,61 @@ export const GET: RequestHandler = async ({ params, locals, setHeaders, request 
 		const organizationId =
 			auth && auth.type !== 'partial_session' ? auth.organizationId : undefined;
 
-		// Check if this asset is used in a private field
-		// The field metadata (schemaType and fieldPath) is stored when the asset is uploaded
-		let isPrivate = false;
-
+		// Is this asset private?
+		//
+		// The asset stores a pointer to the field it was uploaded into, and the
+		// answer is recomputed from the live schema each time — so flipping
+		// `private: true` in code applies immediately, with no migration.
+		//
+		// When that pointer no longer resolves (the field was renamed or removed)
+		// we fall back to the value stamped on the asset at upload. Without that
+		// fallback an unresolvable pointer read as "public", so renaming a private
+		// field quietly published everything behind it.
 		const schemaType = asset.metadata?.schemaType;
 		const fieldPath = asset.metadata?.fieldPath;
 
-		if (schemaType && fieldPath) {
-			// Get the schema definition from IN-MEMORY config (always up-to-date with code changes)
-			const schema = cmsEngine.getSchemaTypeByName(schemaType);
+		const resolved = resolveFieldPrivacy(
+			schemaType ? cmsEngine.getSchemaTypeByName(schemaType) : null,
+			fieldPath
+		);
+		const { isPrivate, usedFallback } = isAssetPrivate(resolved, asset.metadata?.private);
 
-			if (schema && schema.fields) {
-				// Navigate the field path to find the field definition
-				const findField = (fields: any[], path: string): any => {
-					const parts = path.split('.');
-					let current: any = null;
-
-					for (let i = 0; i < parts.length; i++) {
-						const part = parts[i];
-						current = fields.find((f) => f.name === part);
-
-						if (!current) return null;
-
-						// If not the last part, navigate into nested fields
-						if (i < parts.length - 1) {
-							if (current.type === 'object' && current.fields) {
-								fields = current.fields;
-							} else {
-								return null;
-							}
-						}
-					}
-
-					return current;
-				};
-
-				const field = findField(schema.fields, fieldPath);
-
-				if (field && field.type === 'image') {
-					isPrivate = field.private === true;
-				} else {
-					cmsLogger.warn('[Asset CDN]', `Could not find field: ${schemaType}.${fieldPath}`);
-				}
-			}
+		if (usedFallback) {
+			cmsLogger.warn(
+				'[Asset CDN]',
+				`Field ${schemaType}.${fieldPath} no longer resolves; treating asset ${asset.id} as private ` +
+					'from the value recorded at upload. Re-upload it through the current field to clear this.'
+			);
 		}
 
 		cmsLogger.debug('[Asset CDN]', 'Asset privacy:', { isPrivate, schemaType, fieldPath });
 
+		// A signed URL stands in for a session.
+		//
+		// That is the whole point of it: a private asset has to stay reachable in
+		// an <img>, a <video>, or an emailed link, none of which carry the admin's
+		// cookie. The signature is minted server-side by code that has already
+		// decided this viewer may see the asset, and it expires, so it grants
+		// exactly one asset for a bounded window rather than standing access.
+		//
+		// Checked before the session rules below, and sufficient on its own — a
+		// caller holding a valid signature needs no org membership, because org
+		// membership is not what a public site visitor has.
+		const signedAccess = verifyAssetSignature(
+			config.security?.assetSigningSecret,
+			new URL(request.url).searchParams,
+			asset.id
+		);
+
 		// If asset is private, require auth
-		if (isPrivate && !organizationId) {
+		if (isPrivate && !signedAccess && !organizationId) {
 			cmsLogger.warn('[Asset CDN]', 'Private asset accessed without auth');
 			return new Response('Unauthorized - This asset is private', { status: 401 });
 		}
 
 		// If asset is private, verify user has access to the asset's org
 		// This includes exact match OR parent org accessing child org asset (hierarchy)
-		if (isPrivate && organizationId) {
+		if (isPrivate && !signedAccess && organizationId) {
 			let hasAccess = organizationId === asset.organizationId; // Same org
 
 			// If not same org, check if asset's org is a child of user's org (hierarchy)

--- a/packages/cms-core/src/lib/server/api/routes/assets-direct-upload.ts
+++ b/packages/cms-core/src/lib/server/api/routes/assets-direct-upload.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { cmsLogger } from '../../../utils/logger';
 import { confirmUploadRequest, createUploadUrlRequest } from '../../../api/schemas/assets';
+import { resolveFieldPrivacy } from '../../../utils/asset-privacy';
 import { hasCapability } from '../../../types/capabilities';
 import { resolveMaxUploadBytes, formatMegabytes } from '../../../api/limits';
 import { buildOriginalKey } from '../../../storage/keys';
@@ -202,7 +203,15 @@ export const assetsDirectUploadRouter: Hono<AphexEnv> = new Hono<AphexEnv>()
 					description: body.description,
 					alt: body.alt,
 					creditLine: body.creditLine,
-					createdBy: auth.type === 'session' ? auth.user.id : auth.keyId
+					createdBy: auth.type === 'session' ? auth.user.id : auth.keyId,
+					// Resolved here because this route has the schema and the service
+					// does not; stamped so a later field rename can't publish the asset.
+					private: ticket.schemaType
+						? (resolveFieldPrivacy(
+								c.var.aphexCMS.cmsEngine.getSchemaTypeByName(ticket.schemaType),
+								ticket.fieldPath
+							) ?? undefined)
+						: undefined
 				});
 
 				return c.json({ success: true, data: asset });

--- a/packages/cms-core/src/lib/server/api/routes/assets.ts
+++ b/packages/cms-core/src/lib/server/api/routes/assets.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
+import { isAssetPrivate, resolveFieldPrivacy } from '../../../utils/asset-privacy';
 import { cmsLogger } from '../../../utils/logger';
 import { validateFile } from '../../../utils/mime-detect';
 import { listAssetsQuery } from '../../../api/schemas/assets';
@@ -109,13 +110,32 @@ export const assetsRouter: Hono<AphexEnv> = new Hono<AphexEnv>()
 				// thirty 200px tiles.
 				const imageConfig = resolveImageConfig(c.var.aphexCMS.config?.images);
 
+				// Privacy is reported, not re-derived in the browser.
+				//
+				// It depends on the live schema, which only the server holds, and an
+				// asset uploaded before privacy was stamped has no local answer at all
+				// — so a client-side guess would quietly under-report exactly the
+				// assets a lock badge exists to identify. One resolver, one answer.
+				const assets = fetchedAssets.map((asset) => ({
+					...asset,
+					isPrivate: isAssetPrivate(
+						resolveFieldPrivacy(
+							asset.metadata?.schemaType
+								? c.var.aphexCMS.cmsEngine.getSchemaTypeByName(asset.metadata.schemaType)
+								: null,
+							asset.metadata?.fieldPath
+						),
+						asset.metadata?.private
+					).isPrivate
+				}));
+
 				const pageSize = filters.limit || 20;
 				const currentPage = Math.floor(filters.offset / pageSize) + 1;
 				const totalPages = Math.ceil(total / pageSize);
 
 				return c.json({
 					success: true,
-					data: fetchedAssets,
+					data: assets,
 					pagination: {
 						total,
 						page: currentPage,
@@ -266,7 +286,20 @@ export const assetsRouter: Hono<AphexEnv> = new Hono<AphexEnv>()
 					fieldPath,
 					system,
 					usage,
-					duration: videoDuration
+					duration: videoDuration,
+					// Stamped now so the answer survives the field being renamed or
+					// removed later. The media route still prefers the live schema —
+					// this is only the fallback for a pointer that no longer resolves,
+					// which previously read as "public".
+					...(schemaType
+						? {
+								private:
+									resolveFieldPrivacy(
+										c.var.aphexCMS.cmsEngine.getSchemaTypeByName(schemaType),
+										fieldPath
+									) ?? undefined
+							}
+						: {})
 				}
 			};
 

--- a/packages/cms-core/src/lib/server/index.ts
+++ b/packages/cms-core/src/lib/server/index.ts
@@ -77,6 +77,17 @@ export * from '../schema-utils/index';
 // Content hash utilities (server-side)
 export { createHashForPublishing } from '../utils/content-hash';
 
+// Signed asset URLs — how an app hands a private asset to a viewer who has no
+// admin session. Server-only: minting one requires the signing secret.
+export {
+	signAssetUrl,
+	verifyAssetSignature,
+	DEFAULT_ASSET_URL_TTL_SECONDS,
+	ASSET_SIGNATURE_PARAM,
+	ASSET_EXPIRY_PARAM,
+	type SignedAssetUrlOptions
+} from '../utils/asset-url-signing';
+
 // Preview utilities
 export { getPreviewPerspective, type PreviewPerspective } from '../preview/perspective';
 

--- a/packages/cms-core/src/lib/services/asset-service.ts
+++ b/packages/cms-core/src/lib/services/asset-service.ts
@@ -242,6 +242,12 @@ export class AssetService {
 			alt?: string;
 			creditLine?: string;
 			createdBy?: string;
+			/**
+			 * Privacy resolved from the target field by the caller, which has the
+			 * schema this service does not. Stamped onto the asset so the answer
+			 * survives that field being renamed — see `utils/asset-privacy.ts`.
+			 */
+			private?: boolean;
 		}
 	): Promise<Asset> {
 		if (!this.storage.resolvePath) {
@@ -259,7 +265,8 @@ export class AssetService {
 		let height: number | undefined;
 		let metadata: AssetMetadata = {
 			...(intent.schemaType ? { schemaType: intent.schemaType } : {}),
-			...(intent.fieldPath ? { fieldPath: intent.fieldPath } : {})
+			...(intent.fieldPath ? { fieldPath: intent.fieldPath } : {}),
+			...(extras.private !== undefined ? { private: extras.private } : {})
 		};
 
 		if (assetType === 'image' && size <= DIRECT_UPLOAD_INSPECT_MAX_BYTES) {

--- a/packages/cms-core/src/lib/types/asset.ts
+++ b/packages/cms-core/src/lib/types/asset.ts
@@ -97,6 +97,17 @@ export interface Asset {
 	createdBy: string | null;
 	createdAt: Date | null;
 	updatedAt: Date | null;
+	/**
+	 * Whether this asset requires authorization to read — a signed URL or a
+	 * session in its organization.
+	 *
+	 * **Computed, not stored.** Privacy is declared on the schema field the asset
+	 * was uploaded into, so the answer depends on the live schema and only the
+	 * server can produce it. The list endpoint resolves it once and reports it
+	 * here; adapters never set it, which is why it is optional rather than
+	 * nullable — absent means "nobody has worked it out", not "public".
+	 */
+	isPrivate?: boolean;
 }
 
 /**

--- a/packages/cms-core/src/lib/utils/asset-privacy.ts
+++ b/packages/cms-core/src/lib/utils/asset-privacy.ts
@@ -1,0 +1,85 @@
+// Deciding whether an asset is private.
+//
+// An asset does not store "private". It stores a *pointer* to the field it was
+// uploaded into — `metadata.schemaType` and `metadata.fieldPath` — and the
+// answer is recomputed from the live schema on every request. That is what makes
+// flipping `private: true` in code take effect immediately, with no migration.
+//
+// It also means the answer can stop being computable. Rename or delete that
+// field and the pointer dangles: the lookup returns nothing, and "we don't know"
+// used to be treated as "public" — so renaming a private field silently
+// published every asset behind it. Hence the second half of this file: a
+// resolved value is also stamped onto the asset at upload, and used as the
+// fallback when the live lookup fails.
+
+import type { Field, SchemaType } from '../types/schemas';
+
+/** Field types that hold an asset reference and therefore support `private`. */
+const ASSET_FIELD_TYPES = new Set(['image', 'file']);
+
+/**
+ * Walk a dotted field path (`coverImage`, `seo.ogImage`) to its definition.
+ *
+ * Descends through `object` fields only. A path into an array or a named type
+ * reference returns null rather than guessing — see {@link resolveFieldPrivacy}
+ * for what a null means.
+ */
+export function findFieldByPath(fields: Field[], path: string): Field | null {
+	const parts = path.split('.');
+	let current: Field | null = null;
+	let scope: Field[] = fields;
+
+	for (let i = 0; i < parts.length; i++) {
+		current = scope.find((field) => field.name === parts[i]) ?? null;
+		if (!current) return null;
+
+		if (i < parts.length - 1) {
+			const nested = current as Field & { fields?: Field[] };
+			if (current.type !== 'object' || !nested.fields) return null;
+			scope = nested.fields;
+		}
+	}
+
+	return current;
+}
+
+/**
+ * Is the field at this path private?
+ *
+ * `true`/`false` when the field resolves, and **`null` when it doesn't** — the
+ * schema is gone, the field was renamed, or the path leads somewhere this walker
+ * doesn't follow. Null is deliberately distinct from `false`: the caller has a
+ * stored fallback for "unknown" and must not read it as "public".
+ */
+export function resolveFieldPrivacy(
+	schema: SchemaType | null | undefined,
+	fieldPath: string | undefined
+): boolean | null {
+	if (!schema?.fields || !fieldPath) return null;
+
+	const field = findFieldByPath(schema.fields, fieldPath);
+	if (!field || !ASSET_FIELD_TYPES.has(field.type)) return null;
+
+	return (field as Field & { private?: boolean }).private === true;
+}
+
+/**
+ * The final answer, from the live schema first and the stamped value second.
+ *
+ * Order matters. The live schema wins whenever it can answer, so toggling
+ * `private` in code still takes effect at once for every asset pointing at that
+ * field. The stamp is consulted only when the pointer no longer resolves, which
+ * is exactly the rename/delete case that used to fail open.
+ *
+ * An asset with neither — uploaded through the media library before this
+ * existed, or through the API with no field context — is public, as it always
+ * was. Treating "no information at all" as private would turn every existing
+ * library asset inaccessible overnight, which is a different kind of broken.
+ */
+export function isAssetPrivate(
+	resolved: boolean | null,
+	stampedPrivate: unknown
+): { isPrivate: boolean; usedFallback: boolean } {
+	if (resolved !== null) return { isPrivate: resolved, usedFallback: false };
+	return { isPrivate: stampedPrivate === true, usedFallback: stampedPrivate === true };
+}

--- a/packages/cms-core/src/lib/utils/asset-url-signing.ts
+++ b/packages/cms-core/src/lib/utils/asset-url-signing.ts
@@ -1,0 +1,107 @@
+// Signing and verifying `/media/:id/:filename` URLs.
+//
+// The point is that a private asset stays reachable *through the CMS* without a
+// session — an <img> in an email, a <video> on a page rendered for an entitled
+// visitor, a download link with a deadline — while the bucket itself stays
+// closed and its layout stays invisible.
+//
+// This is deliberately not `config.signedDownloads`, which redirects to a
+// signed URL on the *bucket*. That works, but it hands the viewer a
+// `r2.cloudflarestorage.com` URL, exposes the storage key layout, and moves the
+// asset outside every check this route performs — including range handling and
+// derivative selection. Signing our own URL keeps all of it here.
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+/** Query parameter names, kept in one place since both halves must agree. */
+export const ASSET_SIGNATURE_PARAM = 'sig';
+export const ASSET_EXPIRY_PARAM = 'exp';
+
+/** 15 minutes. Long enough to load a page and start a download, short enough that a leaked link dies. */
+export const DEFAULT_ASSET_URL_TTL_SECONDS = 900;
+
+/**
+ * What the signature covers: the asset and the deadline. Nothing else.
+ *
+ * Not the filename — it is cosmetic, derived from the asset row, and a rename
+ * would silently invalidate live links. Not the requested width either: a
+ * responsive `srcset` asks for the same asset at six widths, and signing the
+ * width would mean six signatures for one image, so the caller would have to
+ * mint them per breakpoint or give up on `srcset`. The question a signature
+ * answers is "may this caller read this asset", not "which rendition" — every
+ * derivative is the same picture, and the access decision is identical for all
+ * of them.
+ */
+function payload(assetId: string, expiresAt: number): string {
+	return `${assetId}:${expiresAt}`;
+}
+
+function sign(secret: string, assetId: string, expiresAt: number): string {
+	return createHmac('sha256', secret).update(payload(assetId, expiresAt)).digest('base64url');
+}
+
+export interface SignedAssetUrlOptions {
+	/** Seconds the link stays valid. Defaults to {@link DEFAULT_ASSET_URL_TTL_SECONDS}. */
+	expiresIn?: number;
+	/** Overrides "now" — for tests, and for minting a link that starts later. */
+	now?: Date;
+}
+
+/**
+ * Append a signature and expiry to a `/media/...` path.
+ *
+ * Returns the path unchanged when no secret is configured. That is the safe
+ * direction: an unsigned URL to a private asset is refused by the route, so a
+ * missing secret costs access rather than granting it.
+ */
+export function signAssetUrl(
+	secret: string | undefined,
+	url: string,
+	assetId: string,
+	options: SignedAssetUrlOptions = {}
+): string {
+	if (!secret) return url;
+
+	const nowSeconds = Math.floor((options.now?.getTime() ?? Date.now()) / 1000);
+	const expiresAt = nowSeconds + (options.expiresIn ?? DEFAULT_ASSET_URL_TTL_SECONDS);
+
+	// Relative paths are the common case here, so parse against a base and keep
+	// only what we were given.
+	const parsed = new URL(url, 'https://placeholder.invalid');
+	parsed.searchParams.set(ASSET_EXPIRY_PARAM, String(expiresAt));
+	parsed.searchParams.set(ASSET_SIGNATURE_PARAM, sign(secret, assetId, expiresAt));
+
+	return url.startsWith('http') ? parsed.toString() : `${parsed.pathname}${parsed.search}`;
+}
+
+/**
+ * Whether this request carries a valid, unexpired signature for this asset.
+ *
+ * Every failure returns `false` rather than throwing or distinguishing itself:
+ * a caller learning *why* a signature was rejected learns something about the
+ * secret. The route treats false exactly as it treats no signature at all.
+ */
+export function verifyAssetSignature(
+	secret: string | undefined,
+	params: URLSearchParams,
+	assetId: string,
+	now: Date = new Date()
+): boolean {
+	if (!secret) return false;
+
+	const signature = params.get(ASSET_SIGNATURE_PARAM);
+	const expiry = params.get(ASSET_EXPIRY_PARAM);
+	if (!signature || !expiry) return false;
+
+	const expiresAt = Number(expiry);
+	if (!Number.isSafeInteger(expiresAt)) return false;
+	if (expiresAt * 1000 <= now.getTime()) return false;
+
+	const expected = Buffer.from(sign(secret, assetId, expiresAt));
+	const actual = Buffer.from(signature);
+	// timingSafeEqual throws on a length mismatch, which is itself an oracle of
+	// sorts — check length first and compare only equal-length buffers.
+	if (expected.length !== actual.length) return false;
+
+	return timingSafeEqual(expected, actual);
+}

--- a/packages/cms-core/tests/asset-privacy.test.ts
+++ b/packages/cms-core/tests/asset-privacy.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import {
+	findFieldByPath,
+	resolveFieldPrivacy,
+	isAssetPrivate
+} from '../src/lib/utils/asset-privacy';
+import type { SchemaType } from '../src/lib/types/schemas';
+
+const schema = {
+	name: 'blog_post',
+	type: 'document',
+	fields: [
+		{ name: 'title', type: 'string' },
+		{ name: 'coverImage', type: 'image', private: true },
+		{ name: 'openGraph', type: 'image' },
+		{ name: 'contract', type: 'file', private: true },
+		{ name: 'seo', type: 'object', fields: [{ name: 'ogImage', type: 'image', private: true }] }
+	]
+} as unknown as SchemaType;
+
+describe('findFieldByPath', () => {
+	it('finds a top-level field and one nested in an object', () => {
+		expect(findFieldByPath(schema.fields!, 'coverImage')?.name).toBe('coverImage');
+		expect(findFieldByPath(schema.fields!, 'seo.ogImage')?.name).toBe('ogImage');
+	});
+
+	it('returns null for a path that does not exist', () => {
+		expect(findFieldByPath(schema.fields!, 'nope')).toBeNull();
+		expect(findFieldByPath(schema.fields!, 'title.nested')).toBeNull();
+	});
+});
+
+describe('resolveFieldPrivacy', () => {
+	it('reads private from image and file fields', () => {
+		expect(resolveFieldPrivacy(schema, 'coverImage')).toBe(true);
+		expect(resolveFieldPrivacy(schema, 'contract')).toBe(true);
+		expect(resolveFieldPrivacy(schema, 'seo.ogImage')).toBe(true);
+		expect(resolveFieldPrivacy(schema, 'openGraph')).toBe(false);
+	});
+
+	it('returns null — not false — when it cannot answer', () => {
+		// The distinction is the whole point: null means "unknown", and the caller
+		// falls back to the stamped value rather than reading it as public.
+		expect(resolveFieldPrivacy(schema, 'renamedAway')).toBeNull();
+		expect(resolveFieldPrivacy(schema, 'title')).toBeNull(); // not an asset field
+		expect(resolveFieldPrivacy(null, 'coverImage')).toBeNull();
+		expect(resolveFieldPrivacy(schema, undefined)).toBeNull();
+	});
+});
+
+describe('isAssetPrivate', () => {
+	it('prefers the live schema, so toggling private applies at once', () => {
+		expect(isAssetPrivate(true, undefined)).toEqual({ isPrivate: true, usedFallback: false });
+		// Field says public now, even though it was private at upload.
+		expect(isAssetPrivate(false, true)).toEqual({ isPrivate: false, usedFallback: false });
+	});
+
+	it('falls back to the stamped value when the field is gone', () => {
+		// The rename case. Without this the asset would read as public.
+		expect(isAssetPrivate(null, true)).toEqual({ isPrivate: true, usedFallback: true });
+	});
+
+	it('treats an asset with no information at all as public', () => {
+		// Library uploads predating field context. Defaulting these to private
+		// would make every existing asset inaccessible overnight.
+		expect(isAssetPrivate(null, undefined)).toEqual({ isPrivate: false, usedFallback: false });
+		expect(isAssetPrivate(null, false)).toEqual({ isPrivate: false, usedFallback: false });
+	});
+});

--- a/packages/cms-core/tests/asset-url-signing.test.ts
+++ b/packages/cms-core/tests/asset-url-signing.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import {
+	signAssetUrl,
+	verifyAssetSignature,
+	ASSET_EXPIRY_PARAM,
+	ASSET_SIGNATURE_PARAM
+} from '../src/lib/utils/asset-url-signing';
+
+const SECRET = 'a-long-enough-test-secret-000000000000';
+const ASSET = 'b3f1c0de-0000-4000-8000-000000000001';
+
+const paramsOf = (url: string) => new URL(url, 'https://x.invalid').searchParams;
+
+describe('signed asset URLs', () => {
+	it('round-trips a signature it just minted', () => {
+		const url = signAssetUrl(SECRET, `/media/${ASSET}/photo.jpg`, ASSET);
+		expect(verifyAssetSignature(SECRET, paramsOf(url), ASSET)).toBe(true);
+	});
+
+	it('keeps the path and preserves existing query params', () => {
+		const url = signAssetUrl(SECRET, `/media/${ASSET}/photo.jpg?w=800`, ASSET);
+		expect(url.startsWith(`/media/${ASSET}/photo.jpg?`)).toBe(true);
+		expect(paramsOf(url).get('w')).toBe('800');
+	});
+
+	it('does not bind the signature to the requested width', () => {
+		// A responsive srcset asks for one asset at several widths. Signing the
+		// width would mean a signature per breakpoint; the access decision is the
+		// same for every rendition of the same picture.
+		const url = signAssetUrl(SECRET, `/media/${ASSET}/photo.jpg?w=800`, ASSET);
+		const wider = new URL(url, 'https://x.invalid');
+		wider.searchParams.set('w', '1600');
+		expect(verifyAssetSignature(SECRET, wider.searchParams, ASSET)).toBe(true);
+	});
+
+	it('rejects a signature minted for a different asset', () => {
+		const url = signAssetUrl(SECRET, `/media/${ASSET}/photo.jpg`, ASSET);
+		expect(verifyAssetSignature(SECRET, paramsOf(url), 'another-asset-id')).toBe(false);
+	});
+
+	it('rejects a different secret', () => {
+		const url = signAssetUrl(SECRET, `/media/${ASSET}/photo.jpg`, ASSET);
+		expect(verifyAssetSignature('not-the-secret', paramsOf(url), ASSET)).toBe(false);
+	});
+
+	it('rejects an expired link', () => {
+		const url = signAssetUrl(SECRET, `/media/${ASSET}/photo.jpg`, ASSET, { expiresIn: 60 });
+		const later = new Date(Date.now() + 61_000);
+		expect(verifyAssetSignature(SECRET, paramsOf(url), ASSET, later)).toBe(false);
+	});
+
+	it('rejects a tampered expiry — the deadline is inside the signature', () => {
+		const url = signAssetUrl(SECRET, `/media/${ASSET}/photo.jpg`, ASSET, { expiresIn: 60 });
+		const extended = new URL(url, 'https://x.invalid');
+		extended.searchParams.set(ASSET_EXPIRY_PARAM, String(2 ** 40));
+		expect(verifyAssetSignature(SECRET, extended.searchParams, ASSET)).toBe(false);
+	});
+
+	it('rejects missing, empty and malformed signatures', () => {
+		expect(verifyAssetSignature(SECRET, new URLSearchParams(), ASSET)).toBe(false);
+
+		const noSig = new URLSearchParams({ [ASSET_EXPIRY_PARAM]: String(2 ** 40) });
+		expect(verifyAssetSignature(SECRET, noSig, ASSET)).toBe(false);
+
+		const garbage = new URLSearchParams({
+			[ASSET_EXPIRY_PARAM]: 'not-a-number',
+			[ASSET_SIGNATURE_PARAM]: 'x'
+		});
+		expect(verifyAssetSignature(SECRET, garbage, ASSET)).toBe(false);
+	});
+
+	it('fails closed when no secret is configured', () => {
+		// Signing returns the URL untouched, and an unsigned URL to a private
+		// asset is refused by the route — so a missing secret costs access rather
+		// than granting it.
+		const url = signAssetUrl(undefined, `/media/${ASSET}/photo.jpg`, ASSET);
+		expect(url).toBe(`/media/${ASSET}/photo.jpg`);
+		expect(verifyAssetSignature(undefined, paramsOf(url), ASSET)).toBe(false);
+	});
+});


### PR DESCRIPTION
`FileField.private` was typed, documented and never checked — the CDN route tested only `field.type === 'image'`, so a private file field served its PDF to anyone with the URL.

Privacy was also unreachable for library uploads: the media browser sent no schemaType/fieldPath, so nothing uploaded there could ever be private. The picker now carries the field it was opened from.

Adds signed URLs on our own domain (`?exp=&sig=`), verified before the session check, so a private asset works in an <img>, a <video>, or an emailed link. security.assetSigningSecret was already in the config type and read by nothing; it now works. The signature covers asset id and expiry only — not the filename, not the requested width.

Fixes a fail-open case: renaming or deleting a private field left the pointer unresolvable, which read as public. The resolved value is now also stamped at upload and used as the fallback.

Adds a read-only lock badge in the media library, computed server-side.
